### PR TITLE
Add GameNpcROE policy to prevent friendly fire and honor ceasefire ISSUE #6

### DIFF
--- a/examples/community/game_npc_logic.csl
+++ b/examples/community/game_npc_logic.csl
@@ -1,0 +1,25 @@
+// =============================================================
+// policy: Game NPC "Friendly Fire" Prevention (#6)
+// =============================================================
+CONFIG {
+  ENFORCEMENT_MODE: BLOCK
+  CHECK_LOGICAL_CONSISTENCY: TRUE
+}
+
+DOMAIN GameNpcROE {
+  VARIABLES {
+    target_faction: String
+    my_faction: String
+    has_peace_treaty: {"TRUE", "FALSE"}
+  }
+
+  STATE_CONSTRAINT no_friendly_fire {
+    ALWAYS True
+    THEN target_faction != my_faction
+  }
+
+  STATE_CONSTRAINT honor_ceasefire {
+    ALWAYS True
+    THEN has_peace_treaty != "TRUE"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a community example policy for NPC rules of engagement (ROE) that:
- Blocks attacks when target_faction == my_faction (no friendly fire)
- Blocks attacks when a peace treaty is active
- Allows attacks otherwise

## Changes
- Added: examples/community/game_npc_logic.csl

## Verification
cslcore verify examples/community/game_npc_logic.csl

## Simulation (expected behavior)
1) Same faction (RED vs RED) -> BLOCKED (no_friendly_fire)
2) Treaty active -> BLOCKED (honor_ceasefire)
3) Enemy and no treaty -> ALLOWED