### PR TITLE
Add API budget manager circuit breaker policy example

### DIFF
--- a/examples/community/api_budget_manager.csl
+++ b/examples/community/api_budget_manager.csl
@@ -1,0 +1,27 @@
+// =============================================================
+// policy: API Budget Manager
+// =============================================================
+CONFIG {
+  ENFORCEMENT_MODE: BLOCK
+  CHECK_LOGICAL_CONSISTENCY: TRUE
+}
+
+DOMAIN ApiBudgetManager {
+  VARIABLES {
+    user_tier: {"ENTERPRISE", "PRO", "FREE"}
+    daily_spend: 0.0..100000.0
+    monthly_cumulative: 0.0..1000000.0
+  }
+
+  // FREE users cannot exceed daily spend limit.
+  STATE_CONSTRAINT free_daily_limit {
+    WHEN user_tier == "FREE"
+    THEN daily_spend <= 5.0
+  }
+
+  // PRO users cannot exceed monthly cumulative limit.
+  STATE_CONSTRAINT pro_monthly_limit {
+    WHEN user_tier == "PRO"
+    THEN monthly_cumulative <= 100.0
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new community example policy: `examples/community/api_budget_manager.csl`

This policy acts as a circuit breaker for API budget usage:
- FREE users are blocked when `daily_spend > 5.0`
- PRO users are blocked when `monthly_cumulative > 100.0`
- ENTERPRISE users are always allowed (no extra budget constraints)

## Validation
Verified with `cslcore verify` and simulated test inputs:

- FREE, daily_spend=5.01 -> BLOCKED ✅
- FREE, daily_spend=5.0 -> ALLOWED ✅
- PRO, monthly_cumulative=100.01 -> BLOCKED ✅
- PRO, monthly_cumulative=100.0 -> ALLOWED ✅
- ENTERPRISE, high spend values -> ALLOWED ✅