### PR TITLE
Add PII output guard policy example

### DIFF
--- a/examples/community/pii_guard.csl
+++ b/examples/community/pii_guard.csl
@@ -1,0 +1,34 @@
+// =============================================================
+// CSL-Core Community Example: PII Output Guard
+// Goal: Block agent responses that contain PII or low-confidence output.
+// =============================================================
+
+CONFIG {
+  ENFORCEMENT_MODE: BLOCK
+  CHECK_LOGICAL_CONSISTENCY: TRUE
+}
+
+DOMAIN PiiOutputGuard {
+  VARIABLES {
+    // Raw LLM response text
+    output_text: String
+
+    // Regex scanner signal for PII presence
+    pii_detected: BOOLEAN
+
+    // Model confidence score in [0.0, 1.0]
+    confidence_score: 0.0..1.0
+  }
+
+  // MUST BLOCK if PII is detected.
+  STATE_CONSTRAINT no_pii_in_output {
+    ALWAYS True
+    THEN pii_detected == FALSE
+  }
+
+  // MUST BLOCK if confidence is below 0.70.
+  STATE_CONSTRAINT minimum_confidence {
+    ALWAYS True
+    THEN confidence_score >= 0.70
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a new CSL policy example to prevent a Customer Support AI Agent from accidentally revealing sensitive user data (PII) or emitting low-confidence responses.

- **New file:** `examples/community/pii_guard.csl`
- **Domain:** `PiiOutputGuard`
- **Behavior:**
  1. **BLOCK** if `pii_detected == true`
  2. **BLOCK** if `confidence_score < 0.70`
  3. Otherwise **ALLOW**

## Verification
Policy compiles and is logically consistent (Z3):

```bash
cslcore verify examples/community/pii_guard.csl
```

Expected/Observed result:
- ✅ Validating Syntax... OK  
- ✅ Verifying Logic Model (Z3 Engine)... Mathematically Consistent  
- ✅ Generating IR... OK  

## Simulation Evidence
Commands executed:

```bash
cslcore simulate examples/community/pii_guard.csl --input '{\"output_text\":\"hola\",\"pii_detected\":true,\"confidence_score\":0.95}' --no-raise
cslcore simulate examples/community/pii_guard.csl --input '{\"output_text\":\"hola\",\"pii_detected\":false,\"confidence_score\":0.69}' --no-raise
cslcore simulate examples/community/pii_guard.csl --input '{\"output_text\":\"hola\",\"pii_detected\":false,\"confidence_score\":0.70}' --no-raise
cslcore simulate examples/community/pii_guard.csl --input '{\"output_text\":\"hola\",\"pii_detected\":false,\"confidence_score\":1.0}' --no-raise
```

Observed outcomes:
- ✅ **BLOCKED** when `pii_detected=true` (violation: `no_pii_in_output`)
- ✅ **BLOCKED** when `confidence_score=0.69` (violation: `minimum_confidence`)
- ✅ **ALLOWED** when `confidence_score=0.70` (threshold edge case)
- ✅ **ALLOWED** when `confidence_score=1.0`

## Notes
- The policy uses state constraints to enforce:
  - `pii_detected == FALSE`
  - `confidence_score >= 0.70`
- This matches the issue requirements exactly.


